### PR TITLE
Fix for windows 8

### DIFF
--- a/commands/generate.js
+++ b/commands/generate.js
@@ -121,14 +121,14 @@ exports.default = Command.extend({
                 dryRun: commandOptions.dryRun
             };
             const parsedPath = dynamic_path_parser_1.dynamicPathParser(dynamicPathOptions);
-            commandOptions.sourceDir = appConfig.root;
-            const root = appConfig.root + path.sep;
-            commandOptions.appRoot = parsedPath.appRoot === appConfig.root ? '' :
+            commandOptions.sourceDir = parsedPath.sourceDir;
+            const root = parsedPath.sourceDir + path.sep;
+            commandOptions.appRoot = parsedPath.appRoot === parsedPath.sourceDir ? '' :
                 parsedPath.appRoot.startsWith(root)
                     ? parsedPath.appRoot.substr(root.length)
                     : parsedPath.appRoot;
             commandOptions.path = parsedPath.dir.replace(separatorRegEx, '/');
-            commandOptions.path = parsedPath.dir === appConfig.root ? '' :
+            commandOptions.path = parsedPath.dir === parsedPath.sourceDir ? '' :
                 parsedPath.dir.startsWith(root)
                     ? commandOptions.path.substr(root.length)
                     : commandOptions.path;

--- a/utilities/dynamic-path-parser.js
+++ b/utilities/dynamic-path-parser.js
@@ -6,8 +6,10 @@ const fs = require("fs-extra");
 const stringUtils = require('ember-cli-string-utils');
 function dynamicPathParser(options) {
     const projectRoot = options.project.root;
-    const sourceDir = options.appConfig.root;
-    const p = options.appConfig.appRoot === undefined ? 'app' : options.appConfig.appRoot;
+    const sourceDir = options.appConfig.root.replace(/\//g, path.sep);
+    const p = options.appConfig.appRoot === undefined 
+        ? 'app' 
+        : options.appConfig.appRoot.replace(/\//g, path.sep);
     const appRoot = path.join(sourceDir, p);
     const cwd = process.env.PWD;
     const rootPath = path.join(projectRoot, appRoot);


### PR DESCRIPTION
In @angular/cli 1.6.0, there is a fix which is intended to resolve a problem which only occurs on Windows. 

It resolves the problem, but does not do so for folders which are more than one level deep. NX by defaults creates a two level deep folder structure.

This makes NX actually usable on Windows 8.1.

